### PR TITLE
 corrected policy default priority

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -62,7 +62,7 @@
     name: "{{ item.name }}"
     node: "{{ item.node | default('rabbit') }}"
     pattern: "{{ item.pattern | default('^$') }}"
-    priority: "{{ item.priority | default(1) }}"
+    priority: "{{ item.priority | default(0) }}"
     state: "{{ item.state | default('present') }}"
     tags: "{{ item.tags | default('') }}"
     vhost: "{{ item.vhost | default('/') }}"


### PR DESCRIPTION
According to https://www.rabbitmq.com/man/rabbitmqctl.1.man.html#Policy%20Management, the default priority of a policy is 0.
