### PR TITLE
fixing dependencies for ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,4 @@ galaxy_info:
     - monitoring
     - networking
 dependencies:
-  - config_encoder_filters
+  - jtyr.config_encoder_filters


### PR DESCRIPTION
Using the `ansible-rabbitmq` roles within the `ansible-galaxy` ecosystem, it is required to prepend the username that was missing. Otherwise that role is not found.

Side-effect:
After this change it is no more possible to use the same role from the git repo itself, due to the "namespaced" dependency, but always from ansible-galaxy.
My consideration i think it is better anyway.